### PR TITLE
Fix getDurationUntil

### DIFF
--- a/src/time.cpp
+++ b/src/time.cpp
@@ -122,27 +122,16 @@ Duration TimePoint::getDurationUntil(const TimePoint& other) const
     assert(hours < 24 && minutes < 60 && seconds < 60);
     assert(other.hours < 24 && other.minutes < 60 && other.seconds < 60);
 
-    auto ds = static_cast<int>(other.seconds) - static_cast<int>(seconds);
-    auto dm = static_cast<int>(other.minutes) - static_cast<int>(minutes);
-    auto dh = static_cast<int>(other.hours) - static_cast<int>(hours);
+    const auto secs = Duration { 0, hours, minutes, seconds }.toSeconds();
+    const auto otherSecs = Duration { 0, other.hours, other.minutes, other.seconds }.toSeconds();
+
+    auto ds = static_cast<int>(otherSecs) - static_cast<int>(secs);
+
     if (ds < 0) {
-        ds += 60;
-        assert(ds > 0 && ds < 60);
-        dm -= 1;
-    }
-    if (dm < 0) {
-        dm += 60;
-        assert(dm > 0 && dm < 60);
-        dh -= 1;
-    }
-    if (dh < 0) {
-        dh += 24;
-        assert(dh > 0 && dh < 24);
+        ds += 24 * 60 * 60;
     }
 
-    return Duration { 0, static_cast<uint32_t>(dh), static_cast<uint32_t>(dm),
-        static_cast<uint32_t>(ds) }
-        .normalized();
+    return Duration::fromSeconds(ds);
 }
 
 std::string toString(const TimePoint& tp)

--- a/unittests/time.cpp
+++ b/unittests/time.cpp
@@ -22,5 +22,5 @@ TEST_CASE("TimePoint::parse fails")
 TEST_CASE("TimePoint::getDurationUntil")
 {
     TEST_CHECK(toString(TimePoint { 12, 4, 3 }.getDurationUntil({ 12, 5, 8 })) == "0d0h1m5s");
-    // TEST_CHECK(toString(TimePoint { 23, 59, 59 }.getDurationUntil({ 0, 0, 0 })) == "0d0h0m1s");
+    TEST_CHECK(toString(TimePoint { 23, 59, 59 }.getDurationUntil({ 0, 0, 0 })) == "0d0h0m1s");
 }


### PR DESCRIPTION
Replace with a much simpler implementation that avoids the complication of the old one.